### PR TITLE
Fixes for 64bit isos and unset XAUTHORITY

### DIFF
--- a/run_woof
+++ b/run_woof
@@ -74,13 +74,24 @@ mkdir $SHARE_MNT
 mount -B "$3" $SHARE_MNT
 
 cp -f /etc/resolv.conf $AUFS_MNT/etc/
-cp -f $XAUTHORITY $AUFS_MNT/root/.Xauthority
+[ -e "$XAUTHORITY" ] && cp -f $XAUTHORITY $AUFS_MNT/root/.Xauthority
 
-linux32 chroot $AUFS_MNT \
-        gdk-pixbuf-query-loaders > "$AUFS_MNT/etc/gtk-2.0/gdk-pixbuf.loaders"
+if [ "${2#*64_}" != "$2" ]; then
+	chroot $AUFS_MNT \
+		gdk-pixbuf-query-loaders > "$AUFS_MNT/etc/gtk-2.0/gdk-pixbuf.loaders"
 
-LC_ALL=C \
-LANG=C \
-HOME=/root \
-XAUTHORITY=/root/.Xauthority \
-linux32 chroot $AUFS_MNT /bin/bash -i
+	LC_ALL=C \
+	LANG=C \
+	HOME=/root \
+	XAUTHORITY=/root/.Xauthority \
+	chroot $AUFS_MNT /bin/bash -i
+else
+	linux32 chroot $AUFS_MNT \
+		gdk-pixbuf-query-loaders > "$AUFS_MNT/etc/gtk-2.0/gdk-pixbuf.loaders"
+
+	LC_ALL=C \
+	LANG=C \
+	HOME=/root \
+	XAUTHORITY=/root/.Xauthority \
+	linux32 chroot $AUFS_MNT /bin/bash -i
+fi


### PR DESCRIPTION
Only run chroot in 32bit mode if it is a 32bit iso.
Also not all versions of puppy set XAUTHORITY